### PR TITLE
Chore: Continous Integration - Code Coverage as a Quality Gate

### DIFF
--- a/.github/workflows/code-coverage-workflow.yml
+++ b/.github/workflows/code-coverage-workflow.yml
@@ -31,7 +31,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/**/lcov.info
-          flags: unittests
+#          files: /coverage/**/lcov.info
+#          flags: unittests
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/code-coverage-workflow.yml
+++ b/.github/workflows/code-coverage-workflow.yml
@@ -1,16 +1,25 @@
-name: Workflow for Codecov example-javascript
-on: [push, pull_request]
+name: Continuous Integration Pipeline
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  checks: write
+  statuses: write
+
 jobs:
   run:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Node 18
+      - name: Set up Node 21
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 21
 
       - name: Install dependencies
         run: yarn
@@ -18,5 +27,11 @@ jobs:
       - name: Run tests and collect coverage
         run: npm run test
 
-      - name: Upload coverage to Codecov
+      - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/**/lcov.info
+          flags: unittests
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/code-coverage-workflow.yml
+++ b/.github/workflows/code-coverage-workflow.yml
@@ -1,0 +1,22 @@
+name: Workflow for Codecov example-javascript
+on: [push, pull_request]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Node 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Run tests and collect coverage
+        run: npm run test
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 0%
+    patch:
+      default:
+        target: 80%
+        threshold: 0%

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --coverage",
     "eject": "react-scripts eject",
     "prepare": "husky install"
   },


### PR DESCRIPTION
Now the overall code coverage must be at least 80%. The total coverage may not decrease. New code must have an 80% coverage as well.

### The following changes were made in this Pull request:
- Enabled test coverage results in package-json
   When the test-script is run, our coverage-results are shown in the console and saved

- Created Continuous Integration workflow 
   It builds the project, runs its tests and uploads the coverage to Codedev to check whether the coverage thresholds are met.